### PR TITLE
disable locale detection

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,10 +4,9 @@ module.exports = {
     loader: "custom",
   },
   i18n: {
-    // locales: ["en-US", "vi-VN"],
-    // defaultLocale: "en-US",
     locales: ["en", "vi"],
     defaultLocale: "vi",
+    localeDetection: false,
   },
   webpack(config) {
     config.module.rules.push({


### PR DESCRIPTION
## Description
-  localeDetection is set to false Next.js will no longer automatically redirect based on the user's preferred locale 


## Why
- Set default locale is Vietnamese
- Disable automate locale detection 


## How to QA
- When user visit bsa.edu.vn, user will see Vietnamese


## Screenshots
![Screen Shot 2022-03-08 at 20 06 24](https://user-images.githubusercontent.com/74655110/157243859-0b159712-24aa-4ace-b818-c400f213b43b.png)

